### PR TITLE
Add cwl files to scannable files

### DIFF
--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -134,7 +134,7 @@ def pull(app_id, pkey, clonedrepo):
 
 def scannable_file(fname):
     """This returns true if 'fname' is the name of a file the config scanner should scan."""
-    return fname.endswith(".yaml") or fname.endswith(".yml") or fname.endswith(".json")
+    return fname.endswith(".yaml") or fname.endswith(".yml") or fname.endswith(".json") or fname.endswith(".cwl")
 
 
 def config_scan(

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -134,7 +134,12 @@ def pull(app_id, pkey, clonedrepo):
 
 def scannable_file(fname):
     """This returns true if 'fname' is the name of a file the config scanner should scan."""
-    return fname.endswith(".yaml") or fname.endswith(".yml") or fname.endswith(".json") or fname.endswith(".cwl")
+    return (
+        fname.endswith(".yaml")
+        or fname.endswith(".yml")
+        or fname.endswith(".json")
+        or fname.endswith(".cwl")
+    )
 
 
 def config_scan(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -37,7 +37,7 @@ click==8.1.7
     # via
     #   black
     #   pip-tools
-cryptography==43.0.0
+cryptography==43.0.1
     # via
     #   moto
     #   pyjwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ cffi==1.16.0
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-cryptography==43.0.0
+cryptography==43.0.1
     # via pyjwt
 deprecated==1.2.14
     # via pygithub


### PR DESCRIPTION
## Add support for workflow files
- Add `.cwl` files to the set of scannable files to ensure these are extracted from Git ready to be deployed to the workflow runner