### PR TITLE
Bugfix/pickle oid fails

### DIFF
--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -221,7 +221,7 @@ def main(parser=None):
     # Repo CR's status.
     patch = {"status": {}}
 
-    time.sleep(300)
+    # time.sleep(300)
 
     # Locate repo / repo destination.
     clonedrepo = GitHubRepo(

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -11,7 +11,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-import time
+import json
 
 import yaml
 from github.Repository import Repository
@@ -135,7 +135,12 @@ def pull(app_id, pkey, clonedrepo):
 
 def scannable_file(fname):
     """This returns true if 'fname' is the name of a file the config scanner should scan."""
-    return fname.endswith(".yaml") or fname.endswith(".yml") or fname.endswith(".json") or fname.endswith(".cwl")
+    return (
+        fname.endswith(".yaml")
+        or fname.endswith(".yml")
+        or fname.endswith(".json")
+        or fname.endswith(".cwl")
+    )
 
 
 def config_scan(
@@ -221,8 +226,6 @@ def main(parser=None):
     # Repo CR's status.
     patch = {"status": {}}
 
-    # time.sleep(300)
-
     # Locate repo / repo destination.
     clonedrepo = GitHubRepo(
         location=None,
@@ -285,7 +288,12 @@ def main(parser=None):
 
     # Print update to Repo CR's status field.
     sys.stderr.write(f"Patch is {patch}\n")
-    # print(yaml.dump(patch, Dumper=Dumper, default_flow_style=False))
+    try:
+        print(yaml.dump(patch, Dumper=Dumper, default_flow_style=False))
+    except BrokenPipeError:
+        print(json.dumps(patch, indent=2))
+    except Exception as e:
+        print(f"Error: {e}")
 
 
 if __name__ == "__main__":

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -134,7 +134,7 @@ def pull(app_id, pkey, clonedrepo):
 
 def scannable_file(fname):
     """This returns true if 'fname' is the name of a file the config scanner should scan."""
-    return fname.endswith(".yaml") or fname.endswith(".yml") or fname.endswith(".json")
+    return fname.endswith(".yaml") or fname.endswith(".yml") or fname.endswith(".json") or fname.endswith(".cwl")
 
 
 def config_scan(

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -13,6 +13,7 @@ import shutil
 import sys
 from pathlib import Path
 
+import pygit2
 import yaml
 from github.Repository import Repository
 
@@ -25,6 +26,12 @@ except ImportError:
 from configscanning import k8sutils
 from configscanning.githubrepo import GitHubRepo
 
+# Custom JSON encoder to handle pygit2.Oid objects
+class CustomJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, pygit2.Oid):
+            return str(obj)
+        return super().default(obj)
 
 def get_parser():
     parser = argparse.ArgumentParser()
@@ -290,7 +297,8 @@ def main(parser=None):
     try:
         print(yaml.dump(patch, Dumper=Dumper, default_flow_style=False))
     except TypeError:
-        print(json.dumps(patch, indent=2))
+        # Serialize using the custom JSON encoder
+        print(json.dumps(patch, cls=CustomJSONEncoder, indent=2))
     except Exception as e:
         print(f"Error: {e}")
 

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -281,7 +281,7 @@ def main(parser=None):
 
     # Print update to Repo CR's status field.
     sys.stderr.write(f"Patch is {patch}\n")
-    print(yaml.dump(patch, Dumper=Dumper, default_flow_style=False))
+    # print(yaml.dump(patch, Dumper=Dumper, default_flow_style=False))
 
 
 if __name__ == "__main__":

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
+import time
 
 import yaml
 from github.Repository import Repository
@@ -219,6 +220,8 @@ def main(parser=None):
     # This will be printed at the end and is the JSON patch required to update the
     # Repo CR's status.
     patch = {"status": {}}
+
+    time.sleep(300)
 
     # Locate repo / repo destination.
     clonedrepo = GitHubRepo(

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -177,7 +177,6 @@ def config_scan(
 
             # Scan the files.
             for fname in files_to_scan:
-                logging.info("looking at file %s", fname)
                 try:
                     with open(clonedrepo.location / fname, "rt", encoding="utf8") as file:
                         if fname.endswith(".yaml") or fname.endswith(".yml"):

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -26,12 +26,14 @@ except ImportError:
 from configscanning import k8sutils
 from configscanning.githubrepo import GitHubRepo
 
+
 # Custom JSON encoder to handle pygit2.Oid objects
 class CustomJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, pygit2.Oid):
             return str(obj)
         return super().default(obj)
+
 
 def get_parser():
     parser = argparse.ArgumentParser()

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -289,7 +289,7 @@ def main(parser=None):
     sys.stderr.write(f"Patch is {patch}\n")
     try:
         print(yaml.dump(patch, Dumper=Dumper, default_flow_style=False))
-    except BrokenPipeError:
+    except TypeError:
         print(json.dumps(patch, indent=2))
     except Exception as e:
         print(f"Error: {e}")

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -6,12 +6,12 @@ Workspaces.
 
 import argparse
 import importlib
+import json
 import logging
 import os
 import shutil
 import sys
 from pathlib import Path
-import json
 
 import yaml
 from github.Repository import Repository

--- a/configscanning/git_change_scanner.py
+++ b/configscanning/git_change_scanner.py
@@ -171,6 +171,7 @@ def config_scan(
 
             # Scan the files.
             for fname in files_to_scan:
+                logging.info("looking at file %s", fname)
                 try:
                     with open(clonedrepo.location / fname, "rt", encoding="utf8") as file:
                         if fname.endswith(".yaml") or fname.endswith(".yml"):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -37,7 +37,7 @@ click==8.1.7
     # via
     #   black
     #   pip-tools
-cryptography==43.0.0
+cryptography==43.0.1
     # via
     #   moto
     #   pyjwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ cffi==1.16.0
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-cryptography==43.0.0
+cryptography==43.0.1
     # via pyjwt
 deprecated==1.2.14
     # via pygithub


### PR DESCRIPTION
## Suggested bugfix
When building and running the latest configscanner along with the eodhp-git-change-scanner repo we see a `TypeError: cannot pickle '_pygit2.Oid'` raised upon completion. This seems to be due to the hashing of the `rePosition` head as this type is no longer supported by the default `yaml.dumps` method. It is not clear why this is no longer working, but a temporary workaround is simply to catch the error and instead use `json.dumps` with a custom JSONEncoder.
I have also tried adding a custom yaml representer for `pygit2.Oid` but this does not seem to work.